### PR TITLE
Add Series X751 and X742 Header Length

### DIFF
--- a/gimmedatwave/gimmedatwave.py
+++ b/gimmedatwave/gimmedatwave.py
@@ -68,6 +68,8 @@ class CAENHeader:
     channel_mask: int
     event_counter: int
     trigger_time_tag: int
+    DC_offset:int = None
+    Start_Index_Cell:int = None
 
     def display(self) -> None:
         """

--- a/gimmedatwave/gimmedatwave.py
+++ b/gimmedatwave/gimmedatwave.py
@@ -68,8 +68,8 @@ class CAENHeader:
     channel_mask: int
     event_counter: int
     trigger_time_tag: int
-    DC_offset:int = None
-    Start_Index_Cell:int = None
+    dc_offset:int = None
+    start_index_cell:int = None
 
     def display(self) -> None:
         """

--- a/gimmedatwave/gimmedatwave.py
+++ b/gimmedatwave/gimmedatwave.py
@@ -15,20 +15,23 @@ class DigitizerFamily(Enum):
     X740 = 2
     X730 = 3
     X725 = 4
+    X751 = 5
 
 
 _DIGITIZER_FAMILY_HEADER_LENGTH_MAP = {
-    DigitizerFamily.X742: HEADER_SIZE,
+    DigitizerFamily.X742: HEADER_SIZE+2,
     DigitizerFamily.X740: HEADER_SIZE,
     DigitizerFamily.X730: HEADER_SIZE,
-    DigitizerFamily.X725: HEADER_SIZE
+    DigitizerFamily.X725: HEADER_SIZE,
+    DigitizerFamily.X751: HEADER_SIZE
 }
 
 _DIGITIZER_FAMILY_HEADER_DTYPE_MAP = {
     DigitizerFamily.X742: HEADER_DTYPE,
     DigitizerFamily.X740: HEADER_DTYPE,
     DigitizerFamily.X730: HEADER_DTYPE,
-    DigitizerFamily.X725: HEADER_DTYPE
+    DigitizerFamily.X725: HEADER_DTYPE,
+    DigitizerFamily.X751: HEADER_DTYPE
 }
 
 # The record length is now calculated automatically.
@@ -36,21 +39,24 @@ _DIGITIZER_FAMILY_RECORD_LENGTH_MAP = {
     DigitizerFamily.X742: 1024,
     DigitizerFamily.X740: 1024,
     DigitizerFamily.X730: 1024,
-    DigitizerFamily.X725: 1030
+    DigitizerFamily.X725: 1030,
+    DigitizerFamily.X751: 1024
 }
 
 _DIGITIZER_FAMILY_RECORD_DTYPE_MAP = {
     DigitizerFamily.X742: np.float32,
     DigitizerFamily.X740: np.uint16,
     DigitizerFamily.X730: np.uint16,
-    DigitizerFamily.X725: np.uint16
+    DigitizerFamily.X725: np.uint16,
+    DigitizerFamily.X751: np.uint16
 }
 
 _DIGITIZER_FAMILY_SAMPLE_RATE_MAP = {
     DigitizerFamily.X742: 5000,
     DigitizerFamily.X740: 62.5,
     DigitizerFamily.X730: 500,
-    DigitizerFamily.X725: 250
+    DigitizerFamily.X725: 250,
+    DigitizerFamily.X751: 1000
 }
 
 
@@ -78,7 +84,7 @@ class CAENHeader:
 @dataclass
 class CAENEvent:
     header: CAENHeader
-    record: np.ndarray
+    record: np.ndarray # Waveform data of this Event
     sample_times: np.ndarray
     id: int = 0
 


### PR DESCRIPTION
Hi! robjfoster
It is really exciting to see this WaveDump Reader you achieved. 

And I tried this reader for DT5742 and V1751. So I add some extra code to make your reader to adapt X751 series. Also, I checked the WaveDump manual and found that the HEADER_SIZE of  X742 should be 10 rather than 8 (I pinned the related content in below figure). I have modified the related code in your reader. I hope this will make this excellent reader better.
![Series742Headers](https://github.com/robjfoster/gimmedatwave/assets/31855564/176ad018-5319-4b8f-8b78-ac9953757fe0)

Best wishes!
Xiaojie Luo